### PR TITLE
Add node-red-contrib-ibm-db2 node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-app",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3480,6 +3480,15 @@
                         "tar": "^4.4.2"
                     }
                 }
+            }
+        },
+        "node-red-contrib-ibm-db2": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/node-red-contrib-ibm-db2/-/node-red-contrib-ibm-db2-0.3.1.tgz",
+            "integrity": "sha512-mC+9T2oLwLi2vS5m9UxUAKul1BV4rrBYOV+qtgHTSzEAuq0PtA6ejTQzpZ+FS++Y+Et2txZU4V1OK2nTbCzt6w==",
+            "requires": {
+                "cfenv": "x",
+                "ibm_db": "2.x"
             }
         },
         "node-red-node-cf-cloudant": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-app",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "dependencies": {
         "@cloudant/cloudant": "^4.2.4",
         "bcrypt": "^5.0.0",
@@ -12,7 +12,8 @@
         "node-red-node-cf-cloudant": "0.x",
         "node-red-node-openwhisk": "0.x",
         "node-red-node-watson": "0.x",
-        "node-red-nodes-cf-sqldb-dashdb": "0.x"
+        "node-red-nodes-cf-sqldb-dashdb": "0.x",
+        "node-red-contrib-ibm-db2": "0.x"
     },
     "scripts": {
         "start": "node --max-old-space-size=160 index.js --settings ./bluemix-settings.js -v"


### PR DESCRIPTION
The starter kit currently pulls in `node-red-nodes-cf-sqldb-dashdb` which provides support for connected to DB2.

However the dashdb branding has been retired for sometime. We have updated and republished the module as `node-red-contrib-ibm-db2`. See https://github.com/node-red-contrib-ibm-cloud/community/issues/4 for details.

This PR adds the new module to the starter kit. It leaves the dashdb module in place for the time being as there may be resources out there that direct users to the dashdb nodes. At some point (tbd) we will pull the plug on that module entirely.

