### PR TITLE
Remove deprecated use of otherwise in red.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-app",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "dependencies": {
         "@cloudant/cloudant": "^4.2.4",
         "bcrypt": "^5.0.0",

--- a/red.js
+++ b/red.js
@@ -251,7 +251,7 @@ module.exports = function(settings) {
       } else {
         RED.log.info(RED.log._("server.headless-mode"));
       }
-    }).otherwise(function(err) {
+    }).catch(function(err) {
       RED.log.error(RED.log._("server.failed-to-start"));
       if (err.stack) {
         RED.log.error(err.stack);


### PR DESCRIPTION
The `red.js` in this repo was copied from the core project's own red.js.

We've spotted a deprecated function call in that code which should have been removed a while ago. This is a result of the fact we used the `when.js` promise library in the very early days of the project. That provided `then/otherwise` functions on the promises it provided.

We're in the process of removing when.js from the code base, in preference to native promises that are now widely available.

We can swap out `otherwise` for `catch` which is the standard equivalent function.
