### PR TITLE
Multi-stage build, shrink production container by 60%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
+FROM registry.access.redhat.com/ubi8:8.4 as build
 
-FROM registry.access.redhat.com/ubi8/nodejs-14:1
-
+RUN  dnf module install --nodocs -y nodejs:14 python39 --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+    && dnf install --nodocs -y make gcc gcc-c++  --setopt=install_weak_deps=0 --disableplugin=subscription-manager \
+    && dnf clean all --disableplugin=subscription-manager
+    
 RUN mkdir -p /opt/app-root/src
 WORKDIR /opt/app-root/src
 COPY package.json /opt/app-root/src
-RUN npm install --only=prod
+RUN npm install --no-audit --no-update-notifier --no-fund --production
 COPY . .
 
-ENV NODE_ENV production
+## Release image
+FROM registry.access.redhat.com/ubi8/nodejs-14-minimal:latest
+
+COPY --from=build /opt/app-root/src /opt/app-root/src/
+
+WORKDIR /opt/app-root/src
+
+ENV NODE_ENV=production
 ENV PORT 3000
 EXPOSE 3000
 


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

This Dockerfile uses a multi-stage build to shrink the production container from 291MB to 119MB.
It adopts registry.access.redhat.com/ubi8/nodejs-14-minimal:latest as the base image for production