### PR TITLE
Upgrade to Node-RED v2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "express": "4.x",
         "http-shutdown": "1.2.2",
         "ibm-cloud-env": "^0",
-        "node-red": "^1.3.5",
+        "node-red": "2.x",
         "node-red-contrib-ibm-db2": "0.x",
         "node-red-node-cf-cloudant": "0.x",
         "node-red-node-openwhisk": "0.x",


### PR DESCRIPTION
Signed-off-by: walicki@us.ibm.com
Node-RED v2.0.x has been available for a month. Stable.